### PR TITLE
TAS-37: AuthProvider, useUser, useSetUser 생성

### DIFF
--- a/src/api/auth/auth.query.ts
+++ b/src/api/auth/auth.query.ts
@@ -1,5 +1,7 @@
 import { useSetUser } from '@/contexts/AuthProvider';
+import api from '@/lib/axios';
 import { useMutation } from '@tanstack/react-query';
+import { InternalAxiosRequestConfig } from 'axios';
 import { useRouter } from 'next/navigation';
 import {
   ChangePasswordRequest,
@@ -16,7 +18,14 @@ export const useLoginMutation = () => {
   return useMutation<LoginResponse, Error, LoginRequest>({
     mutationFn: (body) => authService.login(body).then((res) => res.data),
     onSuccess: (result) => {
-      const { user } = result;
+      const { user, accessToken } = result;
+      if (accessToken) {
+        const requestInterceptor = (config: InternalAxiosRequestConfig) => {
+          config.headers['Authorization'] = `Bearer ${accessToken}`;
+          return config;
+        };
+        api.interceptors.request.use(requestInterceptor);
+      }
       setUser(user);
       router.push('/mydashboard');
     },

--- a/src/api/auth/auth.query.ts
+++ b/src/api/auth/auth.query.ts
@@ -1,4 +1,6 @@
+import { useSetUser } from '@/contexts/AuthProvider';
 import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 import {
   ChangePasswordRequest,
   ChangePasswordResponse,
@@ -9,8 +11,15 @@ import { authService } from './auth.service';
 
 // region 로그인
 export const useLoginMutation = () => {
+  const setUser = useSetUser();
+  const router = useRouter();
   return useMutation<LoginResponse, Error, LoginRequest>({
     mutationFn: (body) => authService.login(body).then((res) => res.data),
+    onSuccess: (result) => {
+      const { user } = result;
+      setUser(user);
+      router.push('/mydashboard');
+    },
   });
 };
 // endregion 로그인

--- a/src/api/auth/auth.service.ts
+++ b/src/api/auth/auth.service.ts
@@ -1,5 +1,4 @@
 import api from '@/lib/axios';
-import { InternalAxiosRequestConfig } from 'axios';
 import {
   ChangePasswordRequest,
   ChangePasswordResponse,
@@ -11,16 +10,7 @@ const PATH = '/auth';
 
 class AuthService {
   async login(body: LoginRequest) {
-    const result = await api.post<LoginResponse>(`${PATH}/login`, body);
-    const { accessToken } = result.data;
-    if (accessToken) {
-      const requestInterceptor = (config: InternalAxiosRequestConfig) => {
-        config.headers['Authorization'] = `Bearer ${accessToken}`;
-        return config;
-      };
-      api.interceptors.request.use(requestInterceptor);
-    }
-    return result;
+    return api.post<LoginResponse>(`${PATH}/login`, body);
   }
   changePassword(body: ChangePasswordRequest) {
     return api.put<ChangePasswordResponse>(`${PATH}/password`, body);

--- a/src/api/auth/auth.service.ts
+++ b/src/api/auth/auth.service.ts
@@ -12,11 +12,10 @@ const PATH = '/auth';
 class AuthService {
   async login(body: LoginRequest) {
     const result = await api.post<LoginResponse>(`${PATH}/login`, body);
-    const { user, accessToken } = result.data;
+    const { accessToken } = result.data;
     if (accessToken) {
       const requestInterceptor = (config: InternalAxiosRequestConfig) => {
         config.headers['Authorization'] = `Bearer ${accessToken}`;
-        localStorage.setItem('user', JSON.stringify(user));
         return config;
       };
       api.interceptors.request.use(requestInterceptor);

--- a/src/api/users/users.query.ts
+++ b/src/api/users/users.query.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
 import {
   CreateUserRequest,
   CreateUserResponse,
@@ -16,8 +17,12 @@ const QUERY_KEYS = {
 
 // region 회원가입
 export const useCreateUserMutation = () => {
+  const router = useRouter();
   return useMutation<CreateUserResponse, Error, CreateUserRequest>({
     mutationFn: (body) => usersService.createUser(body).then((res) => res.data),
+    onSuccess: () => {
+      router.push('/login');
+    },
   });
 };
 // endregion 회원가입

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -1,0 +1,34 @@
+import { User } from '@/api/users/users.schema';
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const AuthContext = createContext<{ user?: User; setUser: (newUser?: User) => void }>({
+  setUser: () => {},
+});
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User>();
+
+  useEffect(() => {
+    const data = localStorage.getItem('user');
+    if (data) {
+      const newUser = JSON.parse(data) as User;
+      setUser(newUser);
+    }
+  }, []);
+
+  return <AuthContext value={{ user, setUser }}>{children}</AuthContext>;
+}
+
+export function useUser() {
+  const { user } = useContext(AuthContext);
+  return user;
+}
+
+export function useSetUser() {
+  const { setUser } = useContext(AuthContext);
+  function handleSetUserData(newUser: User) {
+    setUser(newUser);
+    localStorage.setItem('user', JSON.stringify(newUser));
+  }
+  return handleSetUserData;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { AuthProvider } from '@/contexts/AuthProvider';
 import '@/styles/globals.scss';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { AppProps } from 'next/app';
@@ -7,7 +8,9 @@ export default function App({ Component, pageProps }: AppProps) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <Component {...pageProps} />
+      <AuthProvider>
+        <Component {...pageProps} />
+      </AuthProvider>
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [x] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->

1) AuthProvider 및 useUser, useSetUser 임시 생성
2) 회원가입 시 `/login` 페이지로 화면 이동
3) 로그인 시 `/mydashboard` 페이지로 화면 이동 및 user 정보 세팅

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->

로그인한 후 API 테스트를 원하신다면, 아래와 같이 로그인 버튼을 구현한 후 기능 개발 및 테스트 진행해주세요

```js
import { useLoginMutation } from '@/api/auth/auth.query';

export default function Home() {
  const loginMutation = useLoginMutation();
  function onClickLogin() {
    loginMutation.mutate({ email: 'example@naver.com', password: 'example' }); // 로그인을 원하는 이메일 및 비밀번호로 작성해주세요
  }
  return (
    <>
      <div>랜딩페이지 (테스트 중입니다!)</div>
      <button onClick={onClickLogin}>로그인</button>
    </>
  );
}
```

## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->

## 🙏 리뷰어에게
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 언급해주세요 -->

다음과 같이 POST, PUT, DELETE API의 **성공 응답 시의 로직**을 설정하고 싶다면,

```
2) 회원가입 시 `/login` 페이지로 화면 이동
3) 로그인 시 `/mydashboard` 페이지로 화면 이동 및 user 정보 세팅
```

각자 사용하시는 API의 query level에서 onSuccess를 추가 혹은 수정해주시면 됩니다.

```js
export const useLoginMutation = () => {
  const setUser = useSetUser();
  const router = useRouter();
  return useMutation<LoginResponse, Error, LoginRequest>({
    mutationFn: (body) => authService.login(body).then((res) => res.data),
    onSuccess: (result) => { 
      // 성공 응답 시의 로직은 여기에 작성해주시면 됩니다.
      const { user } = result;
      setUser(user);
      router.push('/mydashboard');
    },
  });
};
```