### PR TITLE
TAS-65: 로그인 후 로그인, 회원가입 페이지 접근 제한 코드 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,9 @@
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^19.0.0",
-        "react-intersection-observer": "^9.16.0"
+        "react-hot-toast": "^2.5.2",
+        "react-intersection-observer": "^9.16.0",
+        "react-spinners": "^0.17.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2179,8 +2181,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3233,6 +3234,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -4502,6 +4512,23 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
     "node_modules/react-intersection-observer": {
       "version": "9.16.0",
       "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz",
@@ -4521,6 +4548,16 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-spinners": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.17.0.tgz",
+      "integrity": "sha512-L/8HTylaBmIWwQzIjMq+0vyaRXuoAevzWoD35wKpNTxxtYXWZp+xtgkfD7Y4WItuX0YvdxMPU79+7VhhmbmuTQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/readdirp": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^19.0.0",
-    "react-intersection-observer": "^9.16.0"
+    "react-hot-toast": "^2.5.2",
+    "react-intersection-observer": "^9.16.0",
+    "react-spinners": "^0.17.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/api/auth/auth.query.ts
+++ b/src/api/auth/auth.query.ts
@@ -2,7 +2,6 @@ import { useSetUser } from '@/contexts/AuthProvider';
 import api from '@/lib/axios';
 import { useMutation } from '@tanstack/react-query';
 import { InternalAxiosRequestConfig } from 'axios';
-import { useRouter } from 'next/navigation';
 import {
   ChangePasswordRequest,
   ChangePasswordResponse,
@@ -16,7 +15,7 @@ import { authService } from './auth.service';
  */
 export const useLoginMutation = () => {
   const setUser = useSetUser();
-  const router = useRouter();
+
   return useMutation<LoginResponse, Error, LoginRequest>({
     mutationFn: (body) => authService.login(body).then((res) => res.data),
     onSuccess: (result) => {
@@ -30,7 +29,6 @@ export const useLoginMutation = () => {
         };
         api.interceptors.request.use(requestInterceptor);
       }
-      router.push('/mydashboard');
     },
   });
 };

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -1,22 +1,30 @@
 import { UserType } from '@/api/users/users.schema';
 import { createContext, useContext, useEffect, useState } from 'react';
 
-const AuthContext = createContext<{ user?: UserType; setUser: (newUser?: UserType) => void }>({
+type AuthContextType = {
+  user: UserType | null | undefined;
+  setUser: (newUser: UserType | null | undefined) => void;
+};
+
+const AuthContext = createContext<AuthContextType>({
+  user: undefined,
   setUser: () => {},
 });
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [user, setUser] = useState<UserType>();
+  const [user, setUser] = useState<UserType | null | undefined>(undefined);
 
   useEffect(() => {
     const data = localStorage.getItem('user');
     if (data) {
       const newUser = JSON.parse(data) as UserType;
       setUser(newUser);
+    } else {
+      setUser(null);
     }
   }, []);
 
-  return <AuthContext value={{ user, setUser }}>{children}</AuthContext>;
+  return <AuthContext.Provider value={{ user, setUser }}>{children}</AuthContext.Provider>;
 }
 
 export function useUser() {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import { OverlayProvider } from '@/contexts/OverlayProvider';
 import '@/styles/globals.scss';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { AppProps } from 'next/app';
+import { Toaster } from 'react-hot-toast';
 
 export default function App({ Component, pageProps }: AppProps) {
   const queryClient = new QueryClient();
@@ -14,6 +15,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <OverlayProvider>
           <AuthLayout>
             <Component {...pageProps} />
+            <Toaster position="top-center" reverseOrder={false} />
           </AuthLayout>
         </OverlayProvider>
       </AuthProvider>

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent, useState } from 'react';
+import { useState, ChangeEvent, FormEvent, useEffect, useRef } from 'react';
 import styles from './styles/login.module.scss';
 import Image from 'next/image';
 import InputForm from './components/InputForm';
@@ -6,19 +6,46 @@ import Link from 'next/link';
 import { useLoginMutation } from '@/api/auth/auth.query';
 import { useOverlay } from '@/contexts/OverlayProvider';
 import OneButtonModal from '@/components/modal/OneButtonModal';
+import { useUser } from '@/contexts/AuthProvider';
+import { useRouter } from 'next/router';
+import { ClipLoader } from 'react-spinners';
+import toast from 'react-hot-toast';
 
 export default function Login() {
-  const [values, setValues] = useState({
-    email: '',
-    password: '',
-  });
-  const [errors, setErrors] = useState({
-    email: '',
-    password: '',
-  });
+  const [values, setValues] = useState({ email: '', password: '' });
+  const [errors, setErrors] = useState({ email: '', password: '' });
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   const loginMutation = useLoginMutation();
   const { close, overlay } = useOverlay();
+  const user = useUser();
+  const router = useRouter();
+  const alreadyRedirectedRef = useRef(false);
+
+  useEffect(() => {
+    const justLoggedIn = localStorage.getItem('justLoggedIn');
+
+    if (user) {
+      if (justLoggedIn === 'true') {
+        localStorage.removeItem('justLoggedIn');
+        alreadyRedirectedRef.current = true;
+        router.replace('/mydashboard');
+        return;
+      }
+
+      if (!alreadyRedirectedRef.current) {
+        toast.error('이미 로그인 된 계정입니다.');
+        alreadyRedirectedRef.current = true;
+        router.replace('/mydashboard');
+      }
+    }
+  }, [user]);
+
+  if (user === undefined)
+    return (
+      <div className={styles.spinnerWrapper}>
+        <ClipLoader color="#4b6ef3" size={40} />
+      </div>
+    );
 
   function isFormValid() {
     return (
@@ -28,10 +55,7 @@ export default function Login() {
 
   function handleInputChange(e: ChangeEvent<HTMLInputElement>) {
     const { name, value } = e.target;
-    setValues((prev) => ({
-      ...prev,
-      [name]: value,
-    }));
+    setValues((prev) => ({ ...prev, [name]: value }));
   }
 
   function validateField(name: string, value: string) {
@@ -45,11 +69,7 @@ export default function Login() {
 
   function handleInputBlur(e: ChangeEvent<HTMLInputElement>) {
     const { name, value } = e.target;
-
-    setErrors((prev) => ({
-      ...prev,
-      [name]: validateField(name, value),
-    }));
+    setErrors((prev) => ({ ...prev, [name]: validateField(name, value) }));
   }
 
   function handleSubmit(e: FormEvent<HTMLFormElement>) {
@@ -59,6 +79,11 @@ export default function Login() {
     loginMutation.mutate(
       { email: values.email, password: values.password },
       {
+        onSuccess: () => {
+          localStorage.setItem('justLoggedIn', 'true');
+          toast.success('로그인 되었습니다!');
+          router.replace('/mydashboard');
+        },
         onError: () =>
           overlay(
             <OneButtonModal onClose={close} message="아이디 또는 비밀번호가 일치하지 않습니다." />,
@@ -69,29 +94,33 @@ export default function Login() {
 
   return (
     <div className={styles.authContainer}>
-      <div className={styles.logoWrapper}>
-        <Link href="/">
-          <Image src="/images/logo/logo-main.svg" width={200} height={280} alt="Taskify 로고" />
-        </Link>
-        <div className={styles.logoTitle}>오늘도 만나서 반가워요!</div>
-      </div>
+      {user ? null : (
+        <>
+          <div className={styles.logoWrapper}>
+            <Link href="/">
+              <Image src="/images/logo/logo-main.svg" width={200} height={280} alt="Taskify 로고" />
+            </Link>
+            <div className={styles.logoTitle}>오늘도 만나서 반가워요!</div>
+          </div>
 
-      <InputForm
-        email={values.email}
-        password={values.password}
-        onChange={handleInputChange}
-        onBlur={handleInputBlur}
-        errors={errors}
-        isFormValid={isFormValid()}
-        onSubmit={handleSubmit}
-      />
+          <InputForm
+            email={values.email}
+            password={values.password}
+            onChange={handleInputChange}
+            onBlur={handleInputBlur}
+            errors={errors}
+            isFormValid={isFormValid()}
+            onSubmit={handleSubmit}
+          />
 
-      <div className={styles.switchAuthWrapper}>
-        회원이 아니신가요?{' '}
-        <Link href="/signup" className={styles.switchAuth}>
-          회원가입 하기
-        </Link>
-      </div>
+          <div className={styles.switchAuthWrapper}>
+            회원이 아니신가요?{' '}
+            <Link href="/signup" className={styles.switchAuth}>
+              회원가입 하기
+            </Link>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/pages/login/styles/login.module.scss
+++ b/src/pages/login/styles/login.module.scss
@@ -40,3 +40,10 @@
   color: s.$color-violet_5534DA;
   text-decoration: underline;
 }
+
+.spinnerWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}

--- a/src/pages/signup/styles/signup.module.scss
+++ b/src/pages/signup/styles/signup.module.scss
@@ -40,3 +40,10 @@
   color: s.$color-violet_5534DA;
   text-decoration: underline;
 }
+
+.spinnerWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [x] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
* 로그인 후 로그인, 회원가입 페이지로 접근 제한하여 /mydashboard로 이동하도록 코드 수정
## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
1. 로그인 후에 로그인 또는 회원가입 페이지에 접근하려고 하면 /mydashboard로 이동합니다. 


## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->
TAS-31, TAS-33

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->
로그인 한 유저가 왜 로그인, 회원가입 페이지로 이동 못하는지를 알리는 간단한 Toast 알림과 로딩중일 때의 spinner 기능 추가했습니다. 

## 🙏 리뷰어에게
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 언급해주세요 -->
* 좀 더 좋은 방법이 있을 것 같은데 지금은 이게 최선인것 같습니다..ㅠ더 좋은 방법 알고 계시면 말씀해주세요!(언제든 환영입니다..🥹😭) 