### PR TITLE
TAS-43: 랜딩페이지 접근 시 첫번째 대시보드 상세 페이지로 리다이렉트

### DIFF
--- a/src/components/sidebar/SideBar.tsx
+++ b/src/components/sidebar/SideBar.tsx
@@ -22,8 +22,9 @@ export default function SideBar({ children }: { children?: React.ReactNode }) {
 
   const totalPage = Math.ceil((data?.totalCount || 10) / 10);
   const firstDashboardId = data?.dashboards?.[0]?.id;
+  const nextPathname = firstDashboardId ? `/dashboard/${firstDashboardId}` : '/mydashboard';
   function handleClickLogo() {
-    router.push(`/dashboard/${firstDashboardId}`);
+    router.push(nextPathname);
   }
 
   function handelClickCreateBtn() {
@@ -41,9 +42,7 @@ export default function SideBar({ children }: { children?: React.ReactNode }) {
   };
 
   useEffect(() => {
-    const isPublicPage = pathname === '/' || pathname === '/login' || pathname === '/signup';
-    if (isSuccess && isPublicPage && firstDashboardId)
-      router.replace(`/dashboard/${firstDashboardId}`);
+    if (isSuccess && pathname === '/') router.replace(nextPathname);
   }, [pathname, isSuccess, data, router]);
 
   return (
@@ -96,7 +95,7 @@ export default function SideBar({ children }: { children?: React.ReactNode }) {
                 ))}
             </div>
             <div className={styles.cardPagination}>
-              {isSuccess && (
+              {isSuccess && !!data.dashboards.length && (
                 <Pagination totalPage={totalPage} currentPage={page} setPage={setPage} />
               )}
             </div>


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->

로그인 상태에서 랜딩페이지 접근 시 첫번쩨 대시보드 상세 페이지로 리다이렉트

```ts
// src/component/sidebar/Sidebar.tsx

  const firstDashboardId = data?.dashboards?.[0]?.id;

  useEffect(() => {
    const isPublicPage = pathname === '/' || pathname === '/login' || pathname === '/signup';
    if (isSuccess && isPublicPage && firstDashboardId)
      router.replace(`/dashboard/${firstDashboardId}`);
  }, [pathname, isSuccess, data, router]);
```

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
1. 
2. 
3.

## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->

## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->

## 🙏 리뷰어에게
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 언급해주세요 -->

`isPublicPage`라는 변수를 통해서 랜딩페이지 뿐만 아니라 
로그인, 회원가입 페이지의 접근 시에도 첫번째 대시보드의 상세 페이지로 이동하도록 하고 있는데

해당 로직이 필요 없다면 제거할테니 알려주시면 감사하겠습니다!